### PR TITLE
Correct GitHub link

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -11,7 +11,7 @@
   },
   "socials": {
     "instagram": "https://instagram.com/harold.ao",
-    "github": "https//github.com/haroldao",
+    "github": "https://github.com/haroldao",
     "behance": "https://be.net/haroldao",
     "dribbble": "https://dribbble.com/haroldao",
     "codepen": "https://codepen.io/haroldao",


### PR DESCRIPTION
A colon in the URL was missing and therefore the link was redirecting to https://haroldao.com/https//github.com/haroldao .